### PR TITLE
Move to the latest solc-js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "postinstall": "node ./formatSolc.js"
   },
   "dependencies": {
-    "solc": "^0.4.1",
+    "solc": "^0.4.10",
     "atom-linter": "^4.3.4"
   },
   "providedServices": {


### PR DESCRIPTION
Most contracts (cfr. https://github.com/OpenZeppelin/zeppelin-solidity) use at least 0.4.8 right now and the linter uses version 0.4.7.