### PR TITLE
Add 'view' and 'pure' keywords

### DIFF
--- a/grammars/solidity.cson
+++ b/grammars/solidity.cson
@@ -68,7 +68,7 @@
   }
   {
     comment: "Language keywords"
-    match: "\\b(var|import|function|constant|if|else|for|while|do|break|continue|returns?|private|public|internal|external|inherited|this|suicide|new|is|throw|\\_)\\b"
+    match: "\\b(var|import|function|constant|view|pure|if|else|for|while|do|break|continue|returns?|private|public|internal|external|inherited|this|suicide|new|is|throw|\\_)\\b"
     name: "keyword.control"
   }
   {


### PR DESCRIPTION
Simple modification for adding 'view' and 'pure' keywords which are not supported yet.